### PR TITLE
Bug fix for prompts exiting

### DIFF
--- a/script.js
+++ b/script.js
@@ -202,11 +202,9 @@ getPasswordOptions()
 if (character < 1) {
   alert("You need to select at least one character type")
   if (alert === true) {
-    character = 0;
-    getPasswordOptions()
+    location.reload()
 } else {
-  character = 0;
-  getPasswordOptions()
+  location.reload()
 }
 } else {
 }


### PR DESCRIPTION
Fixed a bug in the JavaScript file for prompts exiting when they should be reloading, page now reloads in response to the corresponding input. 